### PR TITLE
Check and Check Messages (Issue 075)

### DIFF
--- a/protocol/specification/descriptive.rst
+++ b/protocol/specification/descriptive.rst
@@ -305,6 +305,14 @@ Optional Accessible Properties
    A JSON object regarding the accessible meaning. It has the same specification as the :ref:`module meaning <module-meaning>` property.
 
 
+.. _prop-checkable:
+
+``"checkable"``
+    A boolean value, indicating whether the accessible can be checked with a ``check`` message.
+    If omitted, the accessible is assumed to be not checkable (``checkable == False``), and the SEC node should reply with an :ref:`error-report` (``NotCheckable``) error when a ``check`` message is sent.
+
+    :related issue: :issue:`075 New messages check and checked`
+
 Optional Parameter Properties
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 

--- a/protocol/specification/descriptive.rst
+++ b/protocol/specification/descriptive.rst
@@ -302,16 +302,21 @@ Optional Accessible Properties
 .. _accessible-meaning:
 
 ``"meaning"``
-   A JSON object regarding the accessible meaning. It has the same specification as the :ref:`module meaning <module-meaning>` property.
+    A JSON object regarding the accessible meaning. It has the same
+    specification as the :ref:`module meaning <module-meaning>` property.
 
 
 .. _prop-checkable:
 
 ``"checkable"``
-    A boolean value, indicating whether the accessible can be checked with a ``check`` message.
-    If omitted, the accessible is assumed to be not checkable (``checkable == False``), and the SEC node should reply with an :ref:`error-report` (``NotCheckable``) error when a ``check`` message is sent.
+    A boolean value, indicating whether the accessible can be checked with a
+    ``check`` message.  If omitted, the accessible is assumed to be not
+    checkable (``checkable == false``), and the SEC node should reply with an
+    :ref:`error-report` (``NotCheckable``) error when a ``check`` message is
+    sent.
 
     :related issue: :issue:`075 New messages check and checked`
+
 
 Optional Parameter Properties
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~

--- a/protocol/specification/messages.rst
+++ b/protocol/specification/messages.rst
@@ -501,7 +501,7 @@ an accessible can be checked.
   * The response to a ``check`` message must not depend on the current status of the module.
   * A ``check`` message must not change anything, neither on the hardware nor on any parameter.
   * The ``checked`` and ``check_error`` messages are only sent in response to the ``check`` message on the same connection, and not to other clients with an activat connection.
-  * If the check fails, the error report should indicate whether this is due to the current configuration of the SEC node (:ref:`error-classes <Impossible>`), or because the checked value is outside the range (:ref:`error-classes <RangeError>`) specified by the ``datainfo`` property . 
+  * If the check fails, the error report should indicate whether this is due to the current configuration of the SEC node (:ref:`error-classes <Impossible>`), or because the checked value is outside the range (:ref:`error-classes <RangeError>`) specified by the ``datainfo`` property. 
 
 
 Example:

--- a/protocol/specification/messages.rst
+++ b/protocol/specification/messages.rst
@@ -184,8 +184,8 @@ message will naturally be replied with an ``error_change`` message with an
        module-wise           reply          ``inactive␣<module>``
      `heartbeat`_,           request        ``ping``
       with empty identifier  reply          ``pong␣␣<data-report>``
-     `check value`_          request        ``check␣<module>:<accessible>␣``\ <:ref:`value`>
-         \                   reply          ``checked␣<module>:<accessible>␣``\ <`data-report`>
+     `check value`_          request        ``check␣<module>:<accessible>␣<value>``
+         \                   reply          ``checked␣<module>:<accessible>␣<data-report>``
     ======================= ============== ==================
 
 
@@ -482,34 +482,41 @@ Correct handling of side-effects:
 Check Value
 ~~~~~~~~~~~
 
-The check value message is used to enable *dry run* functionality on 
-:ref:`accessibles <accessibles>` (parameters and commands). It consists of the module 
-and accessible name, in addition to the value to be verified. It allows an ECS to 
-verify if a value can be set on a particular parameter without actually changing it 
-with a :ref:`change value <message-change>` message. Similarly it can be used on 
-commands to check if a value is a valid argument, without 
-:ref:`executing <message-do>` the command. This check goes beyond a simple validity 
-check based on the accessible's datainfo and may depend on the current configuration 
-of the entire SEC node. Upon successful completion of the check, a ``checked`` 
-response is sent, containing a `data-report` of the verified value. The accessible 
-property :ref:`checkable <prop-checkable>` indicates whether 
-an accessible can be checked.  
-
+The check value message is used to enable *dry run* functionality on
+:ref:`accessibles <accessibles>` (parameters and commands). It consists of the
+module and accessible name, in addition to the value to be verified. It allows
+an ECS to verify if a value can be set on a particular parameter without
+actually changing it with a :ref:`change value <message-change>` message.
+Similarly, it can be used on commands to check if a value is a valid argument,
+without :ref:`executing <message-do>` the command. This check goes beyond a
+simple validity check based on the accessible's datainfo and may depend on the
+current configuration of the entire SEC node. Upon successful completion of the
+check, a ``checked`` response is sent, containing a `data-report` of the
+verified value. The accessible property :ref:`checkable <prop-checkable>`
+indicates whether an accessible can be checked.
 
 .. admonition:: Remarks
-  
-  * The response to a ``check`` message must not depend on the current status of the module.
-  * A ``check`` message must not change anything, neither on the hardware nor on any parameter.
-  * The ``checked`` and ``check_error`` messages are only sent in response to the ``check`` message on the same connection, and not to other clients with an activat connection.
-  * If the check fails, the error report should indicate whether this is due to the current configuration of the SEC node (:ref:`error-classes <Impossible>`), or because the checked value is outside the range (:ref:`error-classes <RangeError>`) specified by the ``datainfo`` property. 
+
+    * The response to a ``check`` message must not depend on the current status
+      of the module.
+    * A ``check`` message must not change anything, neither on the hardware nor
+      on any parameter.
+    * The ``checked`` and ``check_error`` messages are only sent in response to
+      the ``check`` message on the same connection, and not to other clients
+      with an activated connection.
+    * If the check fails, the error report should indicate whether this is due
+      to the current configuration of the SEC node (:ref:`Impossible
+      <error-classes>`), or because the checked value is outside the range
+      (:ref:`RangeError <error-classes>`) specified by the ``datainfo``
+      property.
 
 
 Example:
 
 .. code::
 
-  > check mf:target [1.0, 1.0, 2.0]
-  < checked mf:target [[1.0, 1.0, 2.0], {}]  
+    > check mf:target [1.0, 1.0, 2.0]
+    < checked mf:target [[1.0, 1.0, 2.0], {}]
 
 
 :related issue: :issue:`075 New messages check and checked`
@@ -618,10 +625,11 @@ _`Error Classes`:
 
         * - ``ReadOnly``
           - The requested write can not be performed on a readonly value.
-        
+
         * - ``NotCheckable``
-          - The requested check can not be performed on the specified parameter.
-            (i.e. on parameters, where no :ref:`checkable <prop-checkable>` property is present, or if it is set to false.)
+          - The requested check can not be performed on the specified parameter
+            (i.e. on parameters, where no :ref:`checkable <prop-checkable>`
+            property is present, or if it is set to false).
 
         * - ``WrongType``
           - The requested parameter change or command can not be performed as


### PR DESCRIPTION
I have added the `check` and `checked` messages to the specification accoding to Proposal 3 layed out in Issue 075.

### Changelog:
#### 1. Added entry for  check message to message table
I have added the `check` message in the `basic messages` section, where implementation is mandatory. 

#### 2. Added `Check Value` section
Should the Example also include a failed check? Even though Error Replys are not yet formally introduced in the spec at that point ? 

#### 3. Added  `NotCheckable` Error Class
New error class for `check` messages where the optional checkable parameter property is set to false or not present. 

#### 4. Added  optional checkable parameter property


Railroad Diagrams:
The railroad diagrams in the section `Message handling` of `buildingblocks.rst` need to be updated to make the changes consistent:
- `images/defined-requests.svg`
- `images/defined-replies.svg`
- `images/must-accept-requests.svg`
- `images/must-accept-replies.svg`

Is anyone still able to generate these? The source is not included in the repo. 

