### PR TITLE
new meaning dict

### DIFF
--- a/protocol/specification/buildingblocks.rst
+++ b/protocol/specification/buildingblocks.rst
@@ -828,14 +828,18 @@ Optional Module Properties
      :related issue: :issue:`008 Groups and Hierarchy`
 
 ``"meaning"``
-    A dictionary regarding the module meaning. The information is provieded in a machine readable format 
-    1. ``"link"``
+   A dictionary regarding the module meaning. It provides metadata that is useful for interpreting the data in a machine readable format. All entries in the dictionary are optional, with some constraints.
 
-    2. ``"key"``
+   1. ``"link"`` a link to a vocabulary, glossary or onthology. But more preferably a PID (Persistent Identifier) that points to a specific entry. 
+         .. note::
+         If the link does not point directly to an entry, the ``"key"`` field is mandatory 
+    
+   2. ``"key"`` name of the entry that ``"link"`` points to.
+         .. note::
+        This field must not be present if there is no ``"link"`` 
 
-    3.  ``"function"``:a string from an extensible list of predefined meanings:
-
-        * ``"temperature"``   (the sample temperature)
+   3.  ``"function"``:a string from an extensible list of predefined meanings:   
+        * ``"temperature"``   
         * ``"temperature_regulation"`` (to be specified only if different from 'temperature')
         * ``"magneticfield"``
         * ``"electricfield"``
@@ -854,23 +858,27 @@ Optional Module Properties
 
         :related issue: :issue:`026 More Module Meanings`
 
-    4. ``"importance"``  a value describing the importance, with the following values:
-
-        - 10 means the instrument/beamline (Example: room temperature sensor always present)
-        - 20 means the surrounding sample environment (Example: VTI temperature)
-        - 30 means an insert (Example: sample stick of dilution insert)
-        - 40 means an addon added to an insert (Example: a device mounted inside a dilution insert)
+   4. ``"importance"``  a value describing the importance, with the following values:
+        * 10 means the instrument/beamline (Example: room temperature sensor always present)
+        * 20 means the surrounding sample environment (Example: VTI temperature)
+        * 30 means an insert (Example: sample stick of dilution insert)
+        * 40 means an addon added to an insert (Example: a device mounted inside a dilution insert)
 
         Intermediate values might be used. The range for each category starts at the indicated value minus 5
         and ends below the indicated value plus 5.
+       
+      .. note::
+       - This field must not be present if there is no entry for ``"function"`` or ``"link""`` 
 
         :related issue: :issue:`009 Module Meaning`
-
-    5. ``"belongs_to"`` a string that identifies the entity to which the function, referenced in the ``"function"`` field, is associated.
-      predefined associations:
-
+   5. ``"belongs_to"`` string identifying the entity to which the measured quantity (`value <Basic Parameters>`_) of the module is linked. Setting this field forms a relation between the entity and the ``"function"`` field, and thus changes how it is interpreted. 
+      Predefined entities:
         * ``"sample"``
         * ...
+         .. note::
+            - If not present, the default value ``"belongs_to":"sample"`` is assumed.
+            
+
 
 
 .. _implementor:

--- a/protocol/specification/buildingblocks.rst
+++ b/protocol/specification/buildingblocks.rst
@@ -872,14 +872,6 @@ Optional Module Properties
         * ``"sample"``
         * ...
 
-Example:
-
-.. code::
-
-
-
-
-
 
 .. _implementor:
 

--- a/protocol/specification/buildingblocks.rst
+++ b/protocol/specification/buildingblocks.rst
@@ -828,9 +828,12 @@ Optional Module Properties
      :related issue: :issue:`008 Groups and Hierarchy`
 
 ``"meaning"``
-    tuple, with the following two elements:
+    A dictionary regarding the module meaning. The information is provieded in a machine readable format 
+    1. ``"link"``
 
-    1.  a string from an extensible list of predefined meanings:
+    2. ``"key"``
+
+    3.  ``"function"``:a string from an extensible list of predefined meanings:
 
         * ``"temperature"``   (the sample temperature)
         * ``"temperature_regulation"`` (to be specified only if different from 'temperature')
@@ -851,7 +854,7 @@ Optional Module Properties
 
         :related issue: :issue:`026 More Module Meanings`
 
-    2.  a value describing the importance, with the following values:
+    4. ``"importance"``  a value describing the importance, with the following values:
 
         - 10 means the instrument/beamline (Example: room temperature sensor always present)
         - 20 means the surrounding sample environment (Example: VTI temperature)
@@ -862,6 +865,21 @@ Optional Module Properties
         and ends below the indicated value plus 5.
 
         :related issue: :issue:`009 Module Meaning`
+
+    5. ``"belongs_to"`` a string that identifies the entity to which the function, referenced in the ``"function"`` field, is associated.
+      predefined associations:
+
+        * ``"sample"``
+        * ...
+
+Example:
+
+.. code::
+
+
+
+
+
 
 .. _implementor:
 

--- a/protocol/specification/buildingblocks.rst
+++ b/protocol/specification/buildingblocks.rst
@@ -885,7 +885,7 @@ Optional Module Properties
       Intermediate values might be used. The range for each category starts at the indicated value minus 5 and ends below the indicated value plus 5.
        
       .. note::
-         This field must not be present if there is no entry for ``"function"`` or ``"link""`` 
+         This field must not be present if there is no entry for ``"function"`` or ``"link"`` 
 
       :related issue: :issue:`009 Module Meaning`
 

--- a/protocol/specification/buildingblocks.rst
+++ b/protocol/specification/buildingblocks.rst
@@ -830,22 +830,12 @@ Optional Module Properties
 .. _module-meaning:
 
 ``"meaning"``
-   A dictionary regarding the module meaning. It provides metadata that is useful for interpreting measurement data in a machine-readable format. All entries in the dictionary are optional, with some restrictions. A meaning porperty can also be added on the :ref:`parameter-meaning <paremeter level>`.
+   An unordered dictionary regarding the module meaning. It provides metadata that is useful for interpreting measurement data in a machine-readable format. It can have the keys ``function``, ``importance``, ``belongs_to``, ``link`` and ``key``, all of which are optional, with some restrictions. A meaning property can also be added on the :ref:`parameter-meaning <paremeter level>`.
    
    .. note::
       In order for the meaning dicionary to be valid, it must contain at least a ``"link"`` or a ``"function"`` field.
 
-
-   1. ``"link"`` a link to a vocabulary, glossary or ontology. Preferably a PID (Persistent Identifier) pointing to a specific entry. 
-    
-   2. ``"key"`` a key (string) that selects an entry from the knowledge representation that ``"link"`` points to. This mainly serves human readability if ``"link"`` already points to a specific entry. 
-
-      .. note::
-         - This field must not be present if there is no ``"link"`` 
-         - If ``"link"`` does not point directly to an entry, the ``"key"`` field is mandatory
-         
-
-   3. ``"function"`` a string from an extensible list of predefined functions.
+   - ``"function"`` a string from an extensible list of predefined functions.
       
       Predefined ``"functions"``:
          * ``"temperature"``   
@@ -874,7 +864,7 @@ Optional Module Properties
 
         :related issue: :issue:`026 More Module Meanings`
 
-   4. ``"importance"``  an integer value in the range ``[0,50]`` describing the importance. It allows ordering elements of the same ``"function"``/``"link"`` by importance.  
+   - ``"importance"``  an integer value in the range ``[0,50]`` describing the importance. It allows ordering elements of the same tuple of ``"function"`` and ``"belongs_to"`` by importance.  
 
       Predefined values:         
         * 10 means the instrument/beamline (Example: room temperature sensor always present)
@@ -885,34 +875,56 @@ Optional Module Properties
       Intermediate values might be used. The range for each category starts at the indicated value minus 5 and ends below the indicated value plus 5.
        
       .. note::
-         This field must not be present if there is no entry for ``"function"`` or ``"link"`` 
+         - This field can only be present, if and only if there is an entry for ``"function"``        
 
       :related issue: :issue:`009 Module Meaning`
 
-   5. ``"belongs_to"`` a string identifying the entity to which the module is linked. Setting this field forms a relation between the entity and the ``"function"`` field.
+   - ``"belongs_to"`` a string identifying the entity to which the module is linked. Setting this field forms a relation between the entity and the ``"function"`` field.
 
       Predefined entities:       
          * ``"sample"``
          * ``"other"``
+      .. note::
+         - If not present, the default value ``"belongs_to":"other"`` is assumed.
+         - This field can only be present, if there is an entry for ``"function"``
+
+   - ``"link"`` a link to a vocabulary, glossary or ontology. Preferably a PID (Persistent Identifier) pointing to a specific entry. 
+    
+   - ``"key"`` a key (string) that selects an entry from the knowledge representation that ``"link"`` points to. This mainly serves human readability if ``"link"`` already points to a specific entry. 
 
       .. note::
-         If not present, the default value ``"belongs_to":"other"`` is assumed.
-            
+         - This field must not be present if there is no ``"link"`` 
+         - If ``"link"`` does not point directly to an entry, the ``"key"`` field is mandatory
+         
+           
 
 Example:
 
 .. code::
 
    "meaning": {
-      "link": "https://w3id.org/nfdi4cat/voc4cat_0000051",
-      "key": "synthesis temperature",
       "function": "temperature_regulation",
       "importance": 20,
-      "belongs_to": "sample"
+      "belongs_to": "sample",
+      "link": "https://w3id.org/nfdi4cat/voc4cat_0000051",
+      "key": "synthesis temperature"
    }
 
+This reads as:
+Regulation of the sample (``belongs_to``) temperature (``function``) in the surrounding sample environment (``importance``).The ``key`` and ``link`` give additional metadata, saying that the regulated temperature is also the ``synthesis temperature`` of the experiment. 
 
+Allowed key combinations in valid meaning dictionaries:
 
+.. code::
+
+   {function, importance,belongs_to}
+   {function, importance}
+   {key,link}
+   {link}
+   {function, importance,link}
+   {function, importance,key,link}
+   {function, importance,belongs_to,link}
+   {function, importance,belongs_to,key,link}
 
 
 .. _implementor:

--- a/protocol/specification/buildingblocks.rst
+++ b/protocol/specification/buildingblocks.rst
@@ -830,15 +830,18 @@ Optional Module Properties
 ``"meaning"``
    A dictionary regarding the module meaning. It provides metadata that is useful for interpreting the data in a machine readable format. All entries in the dictionary are optional, with some constraints.
 
-   1. ``"link"`` a link to a vocabulary, glossary or onthology. But more preferably a PID (Persistent Identifier) that points to a specific entry. 
-         .. note::
-         If the link does not point directly to an entry, the ``"key"`` field is mandatory 
+   1. ``"link"`` a link to a vocabulary, glossary or ontology. Preferably a PID (Persistent Identifier) pointing to a specific entry. 
+
+      .. note::
+      If the link does not point directly to an entry, the ``"key"`` field is mandatory 
     
    2. ``"key"`` name of the entry that ``"link"`` points to.
-         .. note::
-        This field must not be present if there is no ``"link"`` 
 
-   3.  ``"function"``:a string from an extensible list of predefined meanings:   
+      .. note::
+      This field must not be present if there is no ``"link"`` 
+
+   3.  ``"function"`` a string from an extensible list of predefined meanings:
+          
         * ``"temperature"``   
         * ``"temperature_regulation"`` (to be specified only if different from 'temperature')
         * ``"magneticfield"``
@@ -852,13 +855,13 @@ Optional Module Properties
 
         This list may be extended later.
 
-        ``_regulation`` may be postfixed, if the quantity generating module is different from the
-        (closer to the sample) relevant measuring device. A regulation device MUST have an
+        ``_regulation`` may be postfixed, if the quantity generating module is different from the relevant measuring device. A regulation device MUST have an
         :ref:`interface class <interface-classes>` of at least ``Writable``.
 
         :related issue: :issue:`026 More Module Meanings`
 
    4. ``"importance"``  a value describing the importance, with the following values:
+          
         * 10 means the instrument/beamline (Example: room temperature sensor always present)
         * 20 means the surrounding sample environment (Example: VTI temperature)
         * 30 means an insert (Example: sample stick of dilution insert)
@@ -868,15 +871,19 @@ Optional Module Properties
         and ends below the indicated value plus 5.
        
       .. note::
-       - This field must not be present if there is no entry for ``"function"`` or ``"link""`` 
+      This field must not be present if there is no entry for ``"function"`` or ``"link""`` 
 
-        :related issue: :issue:`009 Module Meaning`
-   5. ``"belongs_to"`` string identifying the entity to which the measured quantity (`value <Basic Parameters>`_) of the module is linked. Setting this field forms a relation between the entity and the ``"function"`` field, and thus changes how it is interpreted. 
+      :related issue: :issue:`009 Module Meaning`
+
+   5. ``"belongs_to"``a string that identifies the entity to which the measured quantity (`value <Basic Parameters>`_) of the module is linked. Setting this field forms a relation between the entity and the ``"function"`` field, and thus changes how it is interpreted. 
+
       Predefined entities:
-        * ``"sample"``
-        * ...
-         .. note::
-            - If not present, the default value ``"belongs_to":"sample"`` is assumed.
+       
+         * ``"sample"``
+         * ...
+
+   .. note::
+   If not present, the default value ``"belongs_to":"sample"`` is assumed.
             
 
 

--- a/protocol/specification/buildingblocks.rst
+++ b/protocol/specification/buildingblocks.rst
@@ -827,16 +827,23 @@ Optional Module Properties
 
      :related issue: :issue:`008 Groups and Hierarchy`
 
+.. _module-meaning:
+
 ``"meaning"``
-   A dictionary regarding the module meaning. It provides metadata that is useful for interpreting measurement data in a machine-readable format. All entries in the dictionary are optional, with some restrictions.
+   A dictionary regarding the module meaning. It provides metadata that is useful for interpreting measurement data in a machine-readable format. All entries in the dictionary are optional, with some restrictions. A meaning porperty can also be added on the :ref:`parameter-meaning <paremeter level>`.
+   
+   .. note::
+      In order for the meaning dicionary to be valid, it must contain at least a ``"link"`` or a ``"function"`` field.
+
 
    1. ``"link"`` a link to a vocabulary, glossary or ontology. Preferably a PID (Persistent Identifier) pointing to a specific entry. 
     
-   2. ``"key"`` name of the entry to which ``"link"`` points.
+   2. ``"key"`` a key (string) that selects an entry from the knowledge representation that ``"link"`` points to. This mainly serves human readability if ``"link"`` already points to a specific entry. 
 
       .. note::
          - This field must not be present if there is no ``"link"`` 
-         - If ``"link"`` does not point directly to an entry, the ``"key"`` field is mandatory 
+         - If ``"link"`` does not point directly to an entry, the ``"key"`` field is mandatory
+         
 
    3. ``"function"`` a string from an extensible list of predefined functions.
       
@@ -851,6 +858,14 @@ Optional Module Properties
          * ``"viscosity"``
          * ``"flowrate"``
          * ``"concentration"``
+         * ``"ph"``
+         * ``"conductivity"``
+         * ``"voltage"``
+         * ``"surfacepressure"``
+         * ``"stress"``
+         * ``"strain"``
+         * ``"shear"``
+         * ``"heliumlevel"``
 
         This list may be extended later.
 
@@ -878,10 +893,10 @@ Optional Module Properties
 
       Predefined entities:       
          * ``"sample"``
-         * ...
+         * ``"other"``
 
-   .. note::
-      If not present, the default value ``"belongs_to":"sample"`` is assumed.
+      .. note::
+         If not present, the default value ``"belongs_to":"other"`` is assumed.
             
 
 Example:
@@ -980,6 +995,11 @@ Optional Parameter Properties
     after the activate command.
 
     The value given here must conform to the Datatype of the accessible.
+
+.. _parameter-meaning:
+``"meaning"``
+   A dictionary regarding the parameter meaning. It has the same specification as the :ref:`module-meaning <module meaning>`.
+   
 
 
 Custom Properties

--- a/protocol/specification/buildingblocks.rst
+++ b/protocol/specification/buildingblocks.rst
@@ -828,30 +828,29 @@ Optional Module Properties
      :related issue: :issue:`008 Groups and Hierarchy`
 
 ``"meaning"``
-   A dictionary regarding the module meaning. It provides metadata that is useful for interpreting the data in a machine readable format. All entries in the dictionary are optional, with some constraints.
+   A dictionary regarding the module meaning. It provides metadata that is useful for interpreting measurement data in a machine-readable format. All entries in the dictionary are optional, with some restrictions.
 
    1. ``"link"`` a link to a vocabulary, glossary or ontology. Preferably a PID (Persistent Identifier) pointing to a specific entry. 
-
-      .. note::
-      If the link does not point directly to an entry, the ``"key"`` field is mandatory 
     
-   2. ``"key"`` name of the entry that ``"link"`` points to.
+   2. ``"key"`` name of the entry to which ``"link"`` points.
 
       .. note::
-      This field must not be present if there is no ``"link"`` 
+         - This field must not be present if there is no ``"link"`` 
+         - If ``"link"`` does not point directly to an entry, the ``"key"`` field is mandatory 
 
-   3.  ``"function"`` a string from an extensible list of predefined meanings:
-          
-        * ``"temperature"``   
-        * ``"temperature_regulation"`` (to be specified only if different from 'temperature')
-        * ``"magneticfield"``
-        * ``"electricfield"``
-        * ``"pressure"``
-        * ``"rotation_z"`` (counter clockwise when looked at 'from sky to earth')
-        * ``"humidity"``
-        * ``"viscosity"``
-        * ``"flowrate"``
-        * ``"concentration"``
+   3. ``"function"`` a string from an extensible list of predefined functions.
+      
+      Predefined ``"functions"``:
+         * ``"temperature"``   
+         * ``"temperature_regulation"`` (to be specified only if different from 'temperature')
+         * ``"magneticfield"``
+         * ``"electricfield"``
+         * ``"pressure"``
+         * ``"rotation_z"`` (counter clockwise when looked at 'from sky to earth')
+         * ``"humidity"``
+         * ``"viscosity"``
+         * ``"flowrate"``
+         * ``"concentration"``
 
         This list may be extended later.
 
@@ -860,31 +859,44 @@ Optional Module Properties
 
         :related issue: :issue:`026 More Module Meanings`
 
-   4. ``"importance"``  a value describing the importance, with the following values:
-          
+   4. ``"importance"``  an integer value in the range ``[0,50]`` describing the importance. It allows ordering elements of the same ``"function"``/``"link"`` by importance.  
+
+      Predefined values:         
         * 10 means the instrument/beamline (Example: room temperature sensor always present)
         * 20 means the surrounding sample environment (Example: VTI temperature)
         * 30 means an insert (Example: sample stick of dilution insert)
         * 40 means an addon added to an insert (Example: a device mounted inside a dilution insert)
 
-        Intermediate values might be used. The range for each category starts at the indicated value minus 5
-        and ends below the indicated value plus 5.
+      Intermediate values might be used. The range for each category starts at the indicated value minus 5 and ends below the indicated value plus 5.
        
       .. note::
-      This field must not be present if there is no entry for ``"function"`` or ``"link""`` 
+         This field must not be present if there is no entry for ``"function"`` or ``"link""`` 
 
       :related issue: :issue:`009 Module Meaning`
 
-   5. ``"belongs_to"``a string that identifies the entity to which the measured quantity (`value <Basic Parameters>`_) of the module is linked. Setting this field forms a relation between the entity and the ``"function"`` field, and thus changes how it is interpreted. 
+   5. ``"belongs_to"`` a string identifying the entity to which the module is linked. Setting this field forms a relation between the entity and the ``"function"`` field.
 
-      Predefined entities:
-       
+      Predefined entities:       
          * ``"sample"``
          * ...
 
    .. note::
-   If not present, the default value ``"belongs_to":"sample"`` is assumed.
+      If not present, the default value ``"belongs_to":"sample"`` is assumed.
             
+
+Example:
+
+.. code::
+
+   "meaning": {
+      "link": "https://w3id.org/nfdi4cat/voc4cat_0000051",
+      "key": "synthesis temperature",
+      "function": "temperature_regulation",
+      "importance": 20,
+      "belongs_to": "sample"
+   }
+
+
 
 
 


### PR DESCRIPTION
Additions in this PR make changes to the `meaning` module property, and add the same `meaning` as optional parameter property. (According to the discussion we had at HZDR)

meaning now is a dict with the fields:
- link
- key
- function
- importance
- belongs_to 

Since all fields in the `meaning` dict are optional, i added some constraints (some combinations dont make any sense). This makes the spec a little convoluted in my eyes.

I am still not very happy with some of the wording, so Iam open for discussion.  


