### PR TITLE
New meaning dict with changes from (HZB meeting)

### DIFF
--- a/protocol/specification/descriptive.rst
+++ b/protocol/specification/descriptive.rst
@@ -129,7 +129,7 @@ Optional Module Properties
 .. _module-meaning:
 
 ``"meaning"``
-   A struct with data regarding the module meaning. It provides metadata that is useful for interpreting measurement data in an automatic fashion. It can have the keys ``function``, ``importance``, ``belongs_to``, ``link`` and ``key``, all of which are optional, with some restrictions. A meaning property can also be added on the :ref:`parameter-meaning <paremeter level>`.
+   A JSON object with data regarding the module meaning. It provides metadata that is useful for interpreting measurement data in an automatic fashion. It can have the keys ``function``, ``importance``, ``belongs_to``, ``link`` and ``key``, all of which are optional, with some restrictions. A meaning property can also be added on the :ref:`parameter-meaning <paremeter level>`.
 
    .. note::
       In order for the meaning dictionary to be valid, it must contain at least a ``"link"`` or a ``"function"`` field.

--- a/protocol/specification/descriptive.rst
+++ b/protocol/specification/descriptive.rst
@@ -127,7 +127,7 @@ Optional Module Properties
     Related issue: :issue:`008 Groups and Hierarchy`
 
 ``"meaning"``
-   An unordered dictionary regarding the module meaning. It provides metadata that is useful for interpreting measurement data in a machine-readable format. It can have the keys ``function``, ``importance``, ``belongs_to``, ``link`` and ``key``, all of which are optional, with some restrictions. A meaning property can also be added on the :ref:`parameter-meaning <paremeter level>`.
+   A struct with data regarding the module meaning. It provides metadata that is useful for interpreting measurement data in an automatic fashion. It can have the keys ``function``, ``importance``, ``belongs_to``, ``link`` and ``key``, all of which are optional, with some restrictions. A meaning property can also be added on the :ref:`parameter-meaning <paremeter level>`.
 
    .. note::
       In order for the meaning dicionary to be valid, it must contain at least a ``"link"`` or a ``"function"`` field.

--- a/protocol/specification/descriptive.rst
+++ b/protocol/specification/descriptive.rst
@@ -126,6 +126,8 @@ Optional Module Properties
 
     Related issue: :issue:`008 Groups and Hierarchy`
 
+.. _module-meaning:
+
 ``"meaning"``
    A struct with data regarding the module meaning. It provides metadata that is useful for interpreting measurement data in an automatic fashion. It can have the keys ``function``, ``importance``, ``belongs_to``, ``link`` and ``key``, all of which are optional, with some restrictions. A meaning property can also be added on the :ref:`parameter-meaning <paremeter level>`.
 

--- a/protocol/specification/descriptive.rst
+++ b/protocol/specification/descriptive.rst
@@ -127,43 +127,102 @@ Optional Module Properties
     Related issue: :issue:`008 Groups and Hierarchy`
 
 ``"meaning"``
-    A tuple, with the following two elements:
+   An unordered dictionary regarding the module meaning. It provides metadata that is useful for interpreting measurement data in a machine-readable format. It can have the keys ``function``, ``importance``, ``belongs_to``, ``link`` and ``key``, all of which are optional, with some restrictions. A meaning property can also be added on the :ref:`parameter-meaning <paremeter level>`.
 
-    1. A string from an extensible list of predefined meanings:
+   .. note::
+      In order for the meaning dicionary to be valid, it must contain at least a ``"link"`` or a ``"function"`` field.
 
-       - ``"temperature"`` (the sample temperature)
-       - ``"temperature_regulation"`` (to be specified only if different from 'temperature')
-       - ``"magneticfield"``
-       - ``"electricfield"``
-       - ``"pressure"``
-       - ``"rotation_z"`` (counter clockwise when looked at 'from sky to earth')
-       - ``"humidity"``
-       - ``"viscosity"``
-       - ``"flowrate"``
-       - ``"concentration"``
+   - ``"function"`` a string from an extensible list of predefined functions.
 
-       This list may be extended later.
+      Predefined ``"functions"``:
+         * ``"temperature"``
+         * ``"temperature_regulation"`` (to be specified only if different from 'temperature')
+         * ``"magneticfield"``
+         * ``"electricfield"``
+         * ``"pressure"``
+         * ``"rotation_z"`` (counter clockwise when looked at 'from sky to earth')
+         * ``"humidity"``
+         * ``"viscosity"``
+         * ``"flowrate"``
+         * ``"concentration"``
+         * ``"ph"``
+         * ``"conductivity"``
+         * ``"voltage"``
+         * ``"surfacepressure"``
+         * ``"stress"``
+         * ``"strain"``
+         * ``"shear"``
+         * ``"heliumlevel"``
 
-       ``_regulation`` may be postfixed if the quantity generating module is
-       different from the (closer to the sample) relevant measuring device. A
-       regulation device MUST have an :ref:`interface class <interface-classes>`
-       of at least ``Writable``.
+        This list may be extended later.
 
-       Related issue: :issue:`026 More Module Meanings`
+        ``_regulation`` may be postfixed, if the quantity generating module is different from the relevant measuring device. A regulation device MUST have an
+        :ref:`interface class <interface-classes>` of at least ``Writable``.
 
-    2. A value describing the importance, with the following values:
+        :related issue: :issue:`026 More Module Meanings`
 
-       - 10 means the instrument/beamline (example: room temperature sensor
-         always present)
-       - 20 means the surrounding sample environment (example: VTI temperature)
-       - 30 means an insert (example: sample stick of dilution insert)
-       - 40 means an addon added to an insert (example: a device mounted inside
-         a dilution insert)
+   - ``"importance"``  an integer value in the range ``[0,50]`` describing the importance. It allows ordering elements of the same tuple of ``"function"`` and ``"belongs_to"`` by importance.
 
-       Intermediate values might be used.  The range for each category starts at
-       the indicated value minus 5 and ends below the indicated value plus 5.
+      Predefined values:
+        * 10 means the instrument/beamline (Example: room temperature sensor always present)
+        * 20 means the surrounding sample environment (Example: VTI temperature)
+        * 30 means an insert (Example: sample stick of dilution insert)
+        * 40 means an addon added to an insert (Example: a device mounted inside a dilution insert)
 
-       Related issue: :issue:`009 Module Meaning`
+      Intermediate values might be used. The range for each category starts at the indicated value minus 5 and ends below the indicated value plus 5.
+
+      .. note::
+         - This field can only be present, if and only if there is an entry for ``"function"``
+
+      :related issue: :issue:`009 Module Meaning`
+
+   - ``"belongs_to"`` a string identifying the entity to which the module is linked. Setting this field forms a relation between the entity and the ``"function"`` field.
+
+      Predefined entities:
+         * ``"sample"``
+         * ``"other"``
+      .. note::
+         - If not present, the default value ``"belongs_to":"other"`` is assumed.
+         - This field can only be present, if there is an entry for ``"function"``
+
+   - ``"link"`` a link to a vocabulary, glossary or ontology. Preferably a PID (Persistent Identifier) pointing to a specific entry.
+
+   - ``"key"`` a key (string) that selects an entry from the knowledge representation that ``"link"`` points to. This mainly serves human readability if ``"link"`` already points to a specific entry.
+
+      .. note::
+         - This field must not be present if there is no ``"link"``
+         - If ``"link"`` does not point directly to an entry, the ``"key"`` field is mandatory
+
+
+
+    Example:
+
+    .. code::
+
+    "meaning": {
+        "function": "temperature_regulation",
+        "importance": 20,
+        "belongs_to": "sample",
+        "link": "https://w3id.org/nfdi4cat/voc4cat_0000051",
+        "key": "synthesis temperature"
+    }
+
+    This reads as:
+    Regulation of the sample (``belongs_to``) temperature (``function``) in the surrounding sample environment (``importance``).The ``key`` and ``link`` give additional metadata, saying that the regulated temperature is also the ``synthesis temperature`` of the experiment.
+
+    Allowed key combinations in valid meaning dictionaries:
+
+    .. code::
+
+    {function, importance,belongs_to}
+    {function, importance}
+    {key,link}
+    {link}
+    {function, importance,link}
+    {function, importance,key,link}
+    {function, importance,belongs_to,link}
+    {function, importance,belongs_to,key,link}
+
 
 .. _implementor:
 
@@ -246,6 +305,10 @@ Optional Parameter Properties
     activate command.
 
     The value given here must conform to the data type of the accessible.
+
+.. _parameter-meaning:
+``"meaning"``
+   A dictionary regarding the parameter meaning. It has the same specification as the :ref:`module-meaning <module meaning>`.
 
 
 Custom Properties

--- a/protocol/specification/descriptive.rst
+++ b/protocol/specification/descriptive.rst
@@ -134,85 +134,88 @@ Optional Module Properties
 
    - ``"function"`` a string from an extensible list of predefined functions.
 
-      Predefined ``"functions"``:
-         * ``"temperature"``
-         * ``"temperature_regulation"`` (to be specified only if different from 'temperature')
-         * ``"magneticfield"``
-         * ``"electricfield"``
-         * ``"pressure"``
-         * ``"rotation_z"`` (counter clockwise when looked at 'from sky to earth')
-         * ``"humidity"``
-         * ``"viscosity"``
-         * ``"flowrate"``
-         * ``"concentration"``
-         * ``"ph"``
-         * ``"conductivity"``
-         * ``"voltage"``
-         * ``"surfacepressure"``
-         * ``"stress"``
-         * ``"strain"``
-         * ``"shear"``
-         * ``"heliumlevel"``
+     Predefined ``"functions"``:
 
-        This list may be extended later.
+     * ``"temperature"``
+     * ``"temperature_regulation"`` (to be specified only if different from 'temperature')
+     * ``"magneticfield"``
+     * ``"electricfield"``
+     * ``"pressure"``
+     * ``"rotation_z"`` (counter clockwise when looked at 'from sky to earth')
+     * ``"humidity"``
+     * ``"viscosity"``
+     * ``"flowrate"``
+     * ``"concentration"``
+     * ``"ph"``
+     * ``"conductivity"``
+     * ``"voltage"``
+     * ``"surfacepressure"``
+     * ``"stress"``
+     * ``"strain"``
+     * ``"shear"``
+     * ``"heliumlevel"``
 
-        ``_regulation`` may be postfixed, if the quantity generating module is different from the relevant measuring device. A regulation device MUST have an
-        :ref:`interface class <interface-classes>` of at least ``Writable``.
+     This list may be extended later.
 
-        :related issue: :issue:`026 More Module Meanings`
+     ``_regulation`` may be postfixed, if the quantity generating module is different from the relevant measuring device. A regulation device MUST have an :ref:`interface class <interface-classes>` of at least ``Writable``.
+
+     :related issue: :issue:`026 More Module Meanings`
 
    - ``"importance"``  an integer value in the range ``[0,50]``. It allows ordering elements with the same tuple of ``"function"`` and ``"belongs_to"`` by importance.
 
-      Predefined values:
-        * 10 means the instrument/beamline (Example: room temperature sensor always present)
-        * 20 means the surrounding sample environment (Example: VTI temperature)
-        * 30 means an insert (Example: sample stick of dilution insert)
-        * 40 means an addon added to an insert (Example: a device mounted inside a dilution insert)
+     Predefined values:
 
-      Intermediate values might be used. The range for each category starts at the indicated value minus 5 and ends below the indicated value plus 5.
+     * 10 means the instrument/beamline (Example: room temperature sensor always present)
+     * 20 means the surrounding sample environment (Example: VTI temperature)
+     * 30 means an insert (Example: sample stick of dilution insert)
+     * 40 means an addon added to an insert (Example: a device mounted inside a dilution insert)
 
-      .. note::
-         - This field can only be present, if and only if there is an entry for ``"function"``
+     Intermediate values might be used. The range for each category starts at the indicated value minus 5 and ends below the indicated value plus 5.
 
-      :related issue: :issue:`009 Module Meaning`
+     .. note::
+          This field can only be present, if and only if there is an entry for ``"function"``
+
+     :related issue: :issue:`009 Module Meaning`
 
    - ``"belongs_to"`` a string identifying the entity to which the module is linked. Setting this field forms a relation between the entity and the ``"function"`` field.
 
-      Predefined entities:
-         * ``"sample"``
-         * ``"other"``
-      .. note::
-         - If not present, the default value ``"belongs_to":"other"`` is assumed.
-         - This field can only be present, if there is an entry for ``"function"``
+     Predefined entities:
+     
+     * ``"sample"``
+     * ``"other"``
+
+     .. note::
+          - If not present, the default value ``"belongs_to":"other"`` is assumed.
+          - This field can only be present, if there is an entry for ``"function"``
 
    - ``"link"`` a link to a vocabulary, glossary or ontology. Preferably a PID (Persistent Identifier) pointing to a specific entry.
 
    - ``"key"`` a key (string) that selects an entry from the knowledge representation that ``"link"`` points to. This mainly serves human readability if ``"link"`` already points to a specific entry.
 
-      .. note::
+     .. note::
          - This field must not be present if there is no ``"link"``
          - If ``"link"`` does not point directly to an entry, the ``"key"`` field is mandatory
 
 
 
-    Example:
+   Example:
 
-    .. code::
+   .. code::
 
-    "meaning": {
+     "meaning": {
         "function": "temperature_regulation",
         "importance": 20,
         "belongs_to": "sample",
         "link": "https://w3id.org/nfdi4cat/voc4cat_0000051",
         "key": "synthesis temperature"
-    }
+     }
 
-    This reads as:
-    Regulation of the sample (``belongs_to``) temperature (``function``) in the surrounding sample environment (``importance``).The ``key`` and ``link`` give additional metadata, saying that the regulated temperature is also the ``synthesis temperature`` of the experiment.
+   This reads as:
+   Regulation of the sample (``belongs_to``) temperature (``function``) in the surrounding sample environment (``importance``).The ``key`` and ``link`` give additional metadata, saying that the regulated temperature is also the ``synthesis temperature`` of the experiment.
 
-    Allowed key combinations in valid meaning dictionaries:
+   Allowed key combinations in valid meaning dictionaries:
 
-    .. code::
+   .. code::
 
     {function, importance,belongs_to}
     {function, importance}

--- a/protocol/specification/descriptive.rst
+++ b/protocol/specification/descriptive.rst
@@ -129,7 +129,7 @@ Optional Module Properties
 .. _module-meaning:
 
 ``"meaning"``
-   A JSON object with data regarding the module meaning. It provides metadata that is useful for interpreting measurement data in an automatic fashion. It can have the keys ``function``, ``importance``, ``belongs_to``, ``link`` and ``key``, all of which are optional, with some restrictions. A meaning property can also be added on the :ref:`parameter-meaning <paremeter level>`.
+   A JSON object with data regarding the module meaning. It provides metadata that is useful for interpreting measurement data in an automatic fashion. It can have the keys ``function``, ``importance``, ``belongs_to``, ``link`` and ``key``, all of which are optional, with some restrictions. A meaning property can also be added on the :ref:`parameter-meaning <paraemeter level>`.
 
    .. note::
       In order for the meaning object to be valid, it must contain at least a ``"link"`` or a ``"function"`` field.

--- a/protocol/specification/descriptive.rst
+++ b/protocol/specification/descriptive.rst
@@ -132,7 +132,7 @@ Optional Module Properties
    A JSON object with data regarding the module meaning. It provides metadata that is useful for interpreting measurement data in an automatic fashion. It can have the keys ``function``, ``importance``, ``belongs_to``, ``link`` and ``key``, all of which are optional, with some restrictions. A meaning property can also be added on the :ref:`parameter-meaning <paremeter level>`.
 
    .. note::
-      In order for the meaning dictionary to be valid, it must contain at least a ``"link"`` or a ``"function"`` field.
+      In order for the meaning object to be valid, it must contain at least a ``"link"`` or a ``"function"`` field.
 
    - ``"function"`` a string from an extensible list of predefined functions.
 
@@ -215,7 +215,7 @@ Optional Module Properties
    This reads as:
    Regulation of the sample (``belongs_to``) temperature (``function``) in the surrounding sample environment (``importance``) .The ``key`` and ``link`` give additional metadata, saying that the regulated temperature is also the ``synthesis temperature`` of the experiment.
 
-   Allowed key combinations in valid meaning dictionaries:
+   Allowed key combinations in valid meaning objects:
 
    .. code::
 
@@ -313,7 +313,7 @@ Optional Parameter Properties
 
 .. _parameter-meaning:
 ``"meaning"``
-   A dictionary regarding the parameter meaning. It has the same specification as the :ref:`module-meaning <module meaning>`.
+   A JSON object regarding the parameter meaning. It has the same specification as the :ref:`module-meaning <module meaning>`.
 
 
 Custom Properties

--- a/protocol/specification/descriptive.rst
+++ b/protocol/specification/descriptive.rst
@@ -219,14 +219,14 @@ Optional Module Properties
 
    .. code::
 
-    {function, importance,belongs_to}
+    {function, importance, belongs_to}
     {function, importance}
-    {key,link}
+    {key, link}
     {link}
-    {function, importance,link}
-    {function, importance,key,link}
-    {function, importance,belongs_to,link}
-    {function, importance,belongs_to,key,link}
+    {function, importance, link}
+    {function, importance, key, link}
+    {function, importance, belongs_to, link}
+    {function, importance, belongs_to, key, link}
 
 
 .. _implementor:

--- a/protocol/specification/descriptive.rst
+++ b/protocol/specification/descriptive.rst
@@ -130,7 +130,7 @@ Optional Module Properties
    A struct with data regarding the module meaning. It provides metadata that is useful for interpreting measurement data in an automatic fashion. It can have the keys ``function``, ``importance``, ``belongs_to``, ``link`` and ``key``, all of which are optional, with some restrictions. A meaning property can also be added on the :ref:`parameter-meaning <paremeter level>`.
 
    .. note::
-      In order for the meaning dicionary to be valid, it must contain at least a ``"link"`` or a ``"function"`` field.
+      In order for the meaning dictionary to be valid, it must contain at least a ``"link"`` or a ``"function"`` field.
 
    - ``"function"`` a string from an extensible list of predefined functions.
 

--- a/protocol/specification/descriptive.rst
+++ b/protocol/specification/descriptive.rst
@@ -186,7 +186,7 @@ Optional Module Properties
 
      .. note::
           - If not present, the default value ``"belongs_to":"other"`` is assumed.
-          - This field can only be present, if there is an entry for ``"function"``
+          - This field can only be present, if there is an entry for ``"function"``.
 
    - ``"link"`` a link to a vocabulary, glossary or ontology. Preferably a PID (Persistent Identifier) pointing to a specific entry.
 
@@ -211,7 +211,7 @@ Optional Module Properties
      }
 
    This reads as:
-   Regulation of the sample (``belongs_to``) temperature (``function``) in the surrounding sample environment (``importance``).The ``key`` and ``link`` give additional metadata, saying that the regulated temperature is also the ``synthesis temperature`` of the experiment.
+   Regulation of the sample (``belongs_to``) temperature (``function``) in the surrounding sample environment (``importance``) .The ``key`` and ``link`` give additional metadata, saying that the regulated temperature is also the ``synthesis temperature`` of the experiment.
 
    Allowed key combinations in valid meaning dictionaries:
 

--- a/protocol/specification/descriptive.rst
+++ b/protocol/specification/descriptive.rst
@@ -161,7 +161,7 @@ Optional Module Properties
 
         :related issue: :issue:`026 More Module Meanings`
 
-   - ``"importance"``  an integer value in the range ``[0,50]`` describing the importance. It allows ordering elements of the same tuple of ``"function"`` and ``"belongs_to"`` by importance.
+   - ``"importance"``  an integer value in the range ``[0,50]``. It allows ordering elements with the same tuple of ``"function"`` and ``"belongs_to"`` by importance.
 
       Predefined values:
         * 10 means the instrument/beamline (Example: room temperature sensor always present)


### PR DESCRIPTION
the new meaning dict spec now better reflects the things we discussed in the SECoP@HMC meeting.

- I added an example for possible key combinations
- updated the rules for, when a key can and cannot be present
- explicitly state that the dict is unordered
- added an explanation on how the meaning dict should be read 